### PR TITLE
Save on focus lost

### DIFF
--- a/AutoSaveFile/AutoSaveFile.csproj
+++ b/AutoSaveFile/AutoSaveFile.csproj
@@ -68,6 +68,7 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Threading, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="PresentationFramework" />
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>

--- a/AutoSaveFile/AutoSaveFilePackage.cs
+++ b/AutoSaveFile/AutoSaveFilePackage.cs
@@ -104,12 +104,6 @@ namespace AutoSaveFile
             _dteWindowEvents.WindowActivated += OnWindowActivated;
         }
 
-
-        public void Close()
-        {
-            System.Windows.Application.Current.Deactivated -= OnDeactivated;
-        }
-
         private void OnDeactivated(object sender, System.EventArgs e)
         {
             try

--- a/AutoSaveFile/OptionPageGrid.cs
+++ b/AutoSaveFile/OptionPageGrid.cs
@@ -14,5 +14,10 @@ namespace AutoSaveFile
         [DisplayName("Excluded File Types")]
         [Description("File types which will be ignored")]
         public string IgnoredFileTypes { get; set; }
+
+        [Category("General")]
+        [DisplayName("Save All Files When VS Loses Focus")]
+        [Description("True saves all the files when VS loses focus")]
+        public bool ShouldSaveAllFilesWhenVSLosesFocus { get; set; } = true;
     }
 }

--- a/AutoSaveFile/source.extension.vsixmanifest
+++ b/AutoSaveFile/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="AutoSaveFile.dee600b4-1678-4538-bad2-bc1e05056118" Version="2.2" Language="en-US" Publisher="Hangjit Rai" />
+        <Identity Id="AutoSaveFile.dee600b4-1678-4538-bad2-bc1e05056118" Version="2.3" Language="en-US" Publisher="Hangjit Rai" />
         <DisplayName>Auto Save File</DisplayName>
         <Description xml:space="preserve">This extension help you to save your changes as you make them without having to type Ctrl-S. The time delay is currently set to 5 seconds. Only exception is when the last added character was period[.].
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # auto-save-vs-extension
 An extension that automatically saves the file as you're working on it.
 
-There are 2 conditions when a changed file is saved.
+There are 2 conditions when changed file/s is saved.
 - The 5 seconds have elapsed since the last change.
 - The file loses focus.
+- The solution loses focus. All the changed files are saved.
 
 
 ### Configurable Settings
 * The time delay can be configured from the options panel. <img src="https://github.com/hrai/auto-save-vs-extension/blob/master/options.png">
 * If you want to exclude some files from auto-saving, you can supply a list of comma-separated file extensions such as '*vb,json,config*'
+* If you want to save all the modified files when Visual Studio loses focus, then enable this to true. Set to True by default.


### PR DESCRIPTION
This will save all the modified files when the application (Visual Studio) loses focus. 

This feature can be turned off.

![image](https://user-images.githubusercontent.com/4055444/71871548-963d0880-316d-11ea-84f7-3bf39c5ed0e0.png)
